### PR TITLE
chore(go.mod): fix module path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean: ## Clean the build directory
 .PHONY: build
 build: ## Build the HTTP server
 	@mkdir -p ./build
-	go build -trimpath -ldflags "-X github.com/flashbots/orderflow-proxy/common.Version=${VERSION}" -v -o ./build/orderflow-proxy cmd/httpserver/main.go
+	go build -trimpath -ldflags "-X github.com/flashbots/tdx-orderflow-proxy/common.Version=${VERSION}" -v -o ./build/orderflow-proxy cmd/httpserver/main.go
 
 ##@ Test & Development
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # orderflow-proxy
 
-[![Goreport status](https://goreportcard.com/badge/github.com/flashbots/orderflow-proxy)](https://goreportcard.com/report/github.com/flashbots/go-template)
-[![Test status](https://github.com/flashbots/orderflow-proxy/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/flashbots/go-template/actions?query=workflow%3A%22Checks%22)
+[![Goreport status](https://goreportcard.com/badge/github.com/flashbots/tdx-orderflow-proxy)](https://goreportcard.com/report/github.com/flashbots/go-template)
+[![Test status](https://github.com/flashbots/tdx-orderflow-proxy/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/flashbots/go-template/actions?query=workflow%3A%22Checks%22)
 
 ## Getting started
 

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/VictoriaMetrics/metrics"
-	"github.com/flashbots/orderflow-proxy/common"
-	"github.com/flashbots/orderflow-proxy/proxy"
+	"github.com/flashbots/tdx-orderflow-proxy/common"
+	"github.com/flashbots/tdx-orderflow-proxy/proxy"
 	"github.com/google/uuid"
 	"github.com/urfave/cli/v2" // imports as package "cli"
 )

--- a/common/vars.go
+++ b/common/vars.go
@@ -3,5 +3,5 @@ package common
 var Version = "dev"
 
 const (
-	PackageName = "github.com/flashbots/orderflow-proxy"
+	PackageName = "github.com/flashbots/tdx-orderflow-proxy"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/flashbots/orderflow-proxy
+module github.com/flashbots/tdx-orderflow-proxy
 
 go 1.22
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/flashbots/orderflow-proxy/metrics"
+	"github.com/flashbots/tdx-orderflow-proxy/metrics"
 )
 
 type Config struct {


### PR DESCRIPTION
## 📝 Summary

I wanted to the the `proxy/types.go` as we discussed, but run into this error:

```
# go get github.com/flashbots/tdx-orderflow-proxy/proxy@latest
go: github.com/flashbots/tdx-orderflow-proxy@v0.1.0 (matching github.com/flashbots/tdx-orderflow-proxy/proxy@latest) requires github.com/flashbots/tdx-orderflow-proxy@v0.1.0: parsing go.mod:
	module declares its path as: github.com/flashbots/orderflow-proxy
	        but was required as: github.com/flashbots/tdx-orderflow-proxy
```

I'll work around it for now by checking out locally and using a `replace` directive.

## ⛱ Motivation and Context

Optionally we could just rename the GH repo instead, I'm open to either.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
