### PR TITLE
feat: Add Bundle Validate methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/flashbots/go-utils v0.8.0
 	github.com/google/uuid v1.6.0
 	github.com/urfave/cli/v2 v2.27.2
+	golang.org/x/crypto v0.22.0
 )
 
 require (
@@ -37,7 +38,6 @@ require (
 	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
-	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect


### PR DESCRIPTION
## 📝 Summary

This adds `Validate` methods to `EthSendBundleArgs` and `MevSendBundleArgs` which return the canonical hash (and UUID for the case of bundles, not sure if we need this for mev-share bundles yet) or an error if the payload fails validation.  Currently the validation isn't exhaustive, I wanted to get your feedback on this overall approach before going further, and of course I'd like to add unit tests to make sure that the generated hashes match our existing codebases.

## ⛱ Motivation and Context

When processing these args on the backend we need to have the canonical hashes and UUIDs, it seems like a good idea to generate these in one spot.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
