### PR TITLE
feat: Add dockerhub image for orderflow proxy sender

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-receiver
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-receiver
+            flashbots/tdx-orderflow-proxy-receiver
           tags: |
             type=sha
             type=semver,pattern={{version}}
@@ -60,6 +62,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.FLASHBOTS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.FLASHBOTS_DOCKERHUB_TOKEN }}
 
       - name: Build and Push with Kaniko
         run: |
@@ -79,9 +87,66 @@ jobs:
             --destination ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-receiver:${{ steps.meta.outputs.version }} \
             ${{ steps.meta.outputs.tags }}
 
+  build-sender-image:
+    name: Build Sender Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sender
+            flashbots/tdx-orderflow-proxy-sender
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.FLASHBOTS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.FLASHBOTS_DOCKERHUB_TOKEN }}
+
+      - name: Build and Push with Kaniko
+        run: |
+          mkdir -p /home/runner/.docker
+
+          echo '{"auths":{"${{ env.REGISTRY }}":{"auth":"'$(echo -n "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" | base64)'"}}}'> /home/runner/.docker/config.json
+
+          docker run \
+            -v ${{ github.workspace }}:/workspace \
+            -v /home/runner/.docker/config.json:/kaniko/.docker/config.json \
+            ${{ env.KANIKO_VERSION }} \
+            --context /workspace \
+            --dockerfile /workspace/Dockerfile \
+            --reproducible \
+            --cache=true \
+            --cache-repo ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache \
+            --destination ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sender:${{ steps.meta.outputs.version }} \
+            ${{ steps.meta.outputs.tags }}
+
   github-release:
     runs-on: ubuntu-latest
-    needs: [build-binary, build-receiver-image]
+    needs: [build-binary, build-receiver-image, build-sender-image]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
## 📝 Summary

As part of the buildernet-playground. Orderflow proxy sender is run outside alongside builder-hub. So to facilitate running all orchestrated in the playground, we need an image of orderflow proxy sender binary to be built and pushed as well

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
